### PR TITLE
clean crossroads testcsprog

### DIFF
--- a/test/Crossroads.Test/Crossroads.Test.csproj
+++ b/test/Crossroads.Test/Crossroads.Test.csproj
@@ -28,16 +28,6 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
-	
-	<Target Name="CopyLauncher" BeforeTargets="CopyAdditionalFiles">
-		<ItemGroup>
-			<LauncherFile Include="..\..\src\Crossroads.Launcher\$(OutDir)**"></LauncherFile>
-			<None Include="@(LauncherFile)">
-				<Link>Crossroads.Launcher\%(LauncherFile.FileName)%(LauncherFile.Extension)</Link>
-				<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			</None>
-		</ItemGroup>
-	</Target>
 
 	<Target Name="CopyAppHost" BeforeTargets="CopyAdditionalFiles" DependsOnTargets="ResolveFrameworkReferences">
 		<ItemGroup>


### PR DESCRIPTION
remove `CopyLauncher` functionality from Crossroads.Test.csproj as it is no more in use