### PR TITLE
Net6 apphost bundling support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 </Project>

--- a/src/Crossroads/Crossroads.csproj
+++ b/src/Crossroads/Crossroads.csproj
@@ -26,8 +26,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.7" />
-		<PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20574.7" />
-		<PackageReference Include="System.IO.Abstractions" Version="3.0.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Crossroads/Crossroads.csproj
+++ b/src/Crossroads/Crossroads.csproj
@@ -17,7 +17,6 @@
 		<ToolCommandName>crossroads</ToolCommandName>
 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
   
   <ItemGroup>

--- a/src/Crossroads/Crossroads.csproj
+++ b/src/Crossroads/Crossroads.csproj
@@ -17,7 +17,7 @@
 		<ToolCommandName>crossroads</ToolCommandName>
 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
   
   <ItemGroup>
@@ -35,7 +35,6 @@
 		<PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20574.7" />
 		<PackageReference Include="System.IO.Abstractions" Version="3.0.2" />
 		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-		<PackageReference Include="Microsoft.NET.HostModel" Version="3.1.6" />
 		<PackageReference Include="GitVersion.MsBuild" Version="5.8.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -59,9 +58,9 @@
 
 <Target Name="CopyBuildFiles" AfterTargets="Build">
     <ItemGroup>
-      <BuildFiles Include=".\$(OutDir)*.*"/>
+      <BuildFiles Include=".\$(OutDir)*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder=".\$(OutDir)LauncherFiles"/>
+    <Copy SourceFiles="@(BuildFiles)" DestinationFolder=".\$(OutDir)LauncherFiles" />
 </Target>
  
  	<ItemGroup Label="Packaging">
@@ -85,8 +84,14 @@
 		  <CopyToPublishDirectory>Always</CopyToPublishDirectory>
 	  </Content>
 	</ItemGroup>
+ 
+ 	<ItemGroup>
+ 	  <Reference Include="Microsoft.NET.HostModel">
+ 	    <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\sdk\6.0.201\Microsoft.NET.HostModel.dll</HintPath>
+ 	  </Reference>
+ 	</ItemGroup>
   
   <Target Name="CleanLauncherDirectory" AfterTargets="Clean">
-    <RemoveDir Directories=".\$(OutDir)LauncherFiles"  />
+    <RemoveDir Directories=".\$(OutDir)LauncherFiles" />
   </Target>
 </Project>

--- a/src/Crossroads/Crossroads.csproj
+++ b/src/Crossroads/Crossroads.csproj
@@ -58,32 +58,32 @@
 
 <Target Name="CopyBuildFiles" AfterTargets="Build">
     <ItemGroup>
-      <BuildFiles Include=".\$(OutDir)*.*" />
+      <BuildFiles Include=".\$(OutDir)*.*"/>
     </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder=".\$(OutDir)LauncherFiles" />
+    <Copy SourceFiles="@(BuildFiles)" DestinationFolder=".\$(OutDir)LauncherFiles"/>
 </Target>
- 
- 	<ItemGroup Label="Packaging">
+
+  <Target Name="Package" AfterTargets="Build">
+    <ItemGroup Label="Packaging">
       <Content Include=".\$(OutDir)LauncherFiles\*">
-		  <Pack>true</Pack>
-		  <PackagePath>.\$(OutDir)LauncherFiles</PackagePath>
-		  <IncludeInPackage>true</IncludeInPackage>
-		  <PackageCopyToOutput>true</PackageCopyToOutput>
-		  <BuildAction>Content</BuildAction>
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		  <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-	  </Content>
-	
-	  <Content Include=".\$(OutDir)apphost\*">
-		  <Pack>true</Pack>
-		  <PackagePath>.\$(OutDir)apphost</PackagePath>
-		  <IncludeInPackage>true</IncludeInPackage>
-		  <PackageCopyToOutput>true</PackageCopyToOutput>
-		  <BuildAction>Content</BuildAction>
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		  <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-	  </Content>
-	</ItemGroup>
+        <Pack>true</Pack>
+        <PackagePath>.\$(OutDir)LauncherFiles</PackagePath>
+        <IncludeInPackage>true</IncludeInPackage>
+        <PackageCopyToOutput>true</PackageCopyToOutput>
+        <BuildAction>Content</BuildAction>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+      </Content><Content Include=".\$(OutDir)apphost\*">
+        <Pack>true</Pack>
+        <PackagePath>.\$(OutDir)apphost</PackagePath>
+        <IncludeInPackage>true</IncludeInPackage>
+        <PackageCopyToOutput>true</PackageCopyToOutput>
+        <BuildAction>Content</BuildAction>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
  
  	<ItemGroup>
  	  <Reference Include="Microsoft.NET.HostModel">

--- a/src/Crossroads/Properties/launchSettings.json
+++ b/src/Crossroads/Properties/launchSettings.json
@@ -1,7 +1,0 @@
-{
-  "profiles": {
-    "Crossroads": {
-      "commandName": "Project"
-    }
-  }
-}

--- a/src/Crossroads/Services/AppHostService.cs
+++ b/src/Crossroads/Services/AppHostService.cs
@@ -12,13 +12,10 @@
  * and limitations under the License.
  */
 
-//using Microsoft.NET.HostModel.AppHost;
-//using Microsoft.NET.HostModel.Bundle;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.NET.HostModel;
 using Microsoft.NET.HostModel.AppHost;
 using Microsoft.NET.HostModel.Bundle;
 
@@ -31,15 +28,10 @@ namespace Crossroads.Services
             var appHostDestinationFilePath = Path.Combine(appHostDirectory, bundleName);
             await Task.Run(() => HostWriter.CreateAppHost(appHostSourceFilePath, appHostDestinationFilePath, appBinaryFilePath, assemblyToCopyResorcesFrom: resourceassemblyPathResult));
 
-            var bundler = new Bundler(bundleName, bundleDirectory, BundleOptions.BundleAllContent, diagnosticOutput: true, targetFrameworkVersion: new Version(6, 0), appAssemblyName: "Crossroads");
+            var bundler = new Bundler(bundleName, bundleDirectory, BundleOptions.BundleAllContent, diagnosticOutput: true, targetFrameworkVersion: new Version(6, 0));
 
-            var dirFiles = GetFileSpecs(appHostDirectory);
-            var link = await Task.Run(() => bundler.GenerateBundle(dirFiles));
-            Console.WriteLine("link");
-            Console.WriteLine(link);
-
-            //var bundler = new Bundler(bundleName, bundleDirectory);
-            //await Task.Run(() => bundler.GenerateBundle(appHostDirectory));
+            var fileSpecs = GetFileSpecs(appHostDirectory);
+            var link = await Task.Run(() => bundler.GenerateBundle(fileSpecs));
         }
 
         private List<FileSpec> GetFileSpecs(string sourceDir)
@@ -53,7 +45,6 @@ namespace Crossroads.Services
             {
                 list.Add(new FileSpec(text, RelativePath(sourceDir, text)));
             }
-
             return list;
         }
 

--- a/test/Crossroads.Test/Crossroads.Test.csproj
+++ b/test/Crossroads.Test/Crossroads.Test.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+	  <TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Crossroads\Crossroads.csproj" />
 	</ItemGroup>

--- a/test/Crossroads.Test/Crossroads.Test.csproj
+++ b/test/Crossroads.Test/Crossroads.Test.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
-	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Crossroads\Crossroads.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
Migrating HostModel 3.1 to 6.1 to support .NET 6