### PR TITLE
Bump SystemIOAbstractions + SystemIOAbstractionsTestingHelpers from 17.2.3 to 19.2.69

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,13 +7,14 @@
 		<MicrosoftExtensionsHostingVersion>7.0.1</MicrosoftExtensionsHostingVersion>
 		<MicrosoftExtensionsConfigurationVersion>7.0.0</MicrosoftExtensionsConfigurationVersion>
 		<SystemCommandLineHostingVersion>0.3.0-alpha.20574.7</SystemCommandLineHostingVersion>
-		<SystemIOAbstractionsVersion>17.2.3</SystemIOAbstractionsVersion>
+    <TestableIOSystemIOAbstractionsWrappersVersion>19.2.69</TestableIOSystemIOAbstractionsWrappersVersion>
 		<MicrosoftCodeAnalysisCSharpVersion>4.7.0</MicrosoftCodeAnalysisCSharpVersion>
 		<MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
 		<NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
 		<MicrosoftExtensionsDependencyModelVersion>6.0.0</MicrosoftExtensionsDependencyModelVersion>
 		<GitVersionMsBuildVersion>5.12.0</GitVersionMsBuildVersion>
-	</PropertyGroup>
+
+</PropertyGroup>
 
 	<PropertyGroup  Label="Dependencies from Test">
 		<CoverletMsBuildVersion>6.0.0</CoverletMsBuildVersion>
@@ -21,7 +22,7 @@
 		<XunitVersion>2.5.3</XunitVersion>
 		<XunitRunnerVisualStudioVersion>2.5.1</XunitRunnerVisualStudioVersion>
 		<MoqVersion>4.20.69</MoqVersion>
-		<SystemIOAbstractionsTestingHelpersVersion>17.2.3</SystemIOAbstractionsTestingHelpersVersion>
+    <TestableIOSystemIOAbstractionsTestingHelpersVersion>19.2.69</TestableIOSystemIOAbstractionsTestingHelpersVersion>
 		<CoverletCollector>3.2.0</CoverletCollector>
 	</PropertyGroup>
 </Project>

--- a/src/Crossroads.Launcher/Crossroads.Launcher.csproj
+++ b/src/Crossroads.Launcher/Crossroads.Launcher.csproj
@@ -15,7 +15,7 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
 		<PackageReference Include="System.CommandLine.Hosting" Version="$(SystemCommandLineHostingVersion)" />
-		<PackageReference Include="System.IO.Abstractions" Version="$(SystemIOAbstractionsVersion)" />
+		<PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="$(TestableIOSystemIOAbstractionsVersion)" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="appsettings.json">

--- a/src/Crossroads/Crossroads.csproj
+++ b/src/Crossroads/Crossroads.csproj
@@ -28,7 +28,7 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationVersion)" />
 		<PackageReference Include="System.CommandLine.Hosting" Version="$(SystemCommandLineHostingVersion)" />
-		<PackageReference Include="System.IO.Abstractions" Version="$(SystemIOAbstractionsVersion)" />
+		<PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="$(TestableIOSystemIOAbstractionsWrappersVersion)" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)">
 			<PrivateAssets>all</PrivateAssets>

--- a/test/Crossroads.Launcher.Test/Crossroads.Launcher.Test.csproj
+++ b/test/Crossroads.Launcher.Test/Crossroads.Launcher.Test.csproj
@@ -25,7 +25,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Moq" Version="$(MoqVersion)" />
-		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="$(SystemIOAbstractionsTestingHelpersVersion)" />
+		<PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="$(TestableIOSystemIOAbstractionsTestingHelpersVersion)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/Crossroads.Test/Crossroads.Test.csproj
+++ b/test/Crossroads.Test/Crossroads.Test.csproj
@@ -19,7 +19,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Moq" Version="$(MoqVersion)" />
-		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="$(SystemIOAbstractionsTestingHelpersVersion)" />
+		<PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="$(TestableIOSystemIOAbstractionsTestingHelpersVersion)" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Using TestableIO.SystemIO.Abstractions library from Microsoft official....

- Upgrade SystemIOAbstractions from v17.2.3 to TestableIOSystemIOAbstractionsWrappers v19.2.69
- Upgrade SystemIOAbstractionsTestingHelpers from v17.2.3 to TestableIOSystemIOAbstractionsTestingHelpers v19.2.69