### PR TITLE
Docs pages path prefix fix

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -4,10 +4,10 @@ module.exports = {
   siteMetadata: {
     title: `Morgan Stanley Open Source Software`,
     description: `Morgan Stanley Open Source Software`,
-    siteUrl: 'http://opensource.morganstanley.com',
+    siteUrl: 'http://opensource.morganstanley.com/crossroads',
     documentationUrl: false,
     //  documentationUrl: url-of.documentation.site,
   },
-  pathPrefix: `/`, // include subdirectory
+  pathPrefix: `/Crossroads`, // include subdirectory
   plugins,
 };

--- a/site/package.json
+++ b/site/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "develop": "gatsby develop -H 0.0.0.0",
     "start": "gatsby develop -H 0.0.0.0",
-    "build": "gatsby clean && gatsby build && npm run pub",
+    "build": "gatsby clean && gatsby build --prefix-paths && npm run pub",
     "serve": "gatsby serve",
     "pub": "rm -rf ../docs && mv public ../docs",
     "clean": "gatsby clean"


### PR DESCRIPTION
Adds `/Crossroads` to the path prefix in the links to documentation