### PR TITLE
update dotnet 8 (#186)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
-            6.0.x
+            8.0.x
       - name: Restore dependencies
         run: dotnet restore --locked-mode
       - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Dependencies from crossroads and Launcher">
@@ -19,10 +19,10 @@
 	<PropertyGroup  Label="Dependencies from Test">
 		<CoverletMsBuildVersion>6.0.0</CoverletMsBuildVersion>
 		<MicrosoftNETTestSdkVersion>17.8.0</MicrosoftNETTestSdkVersion>
-		<XunitVersion>2.6.4</XunitVersion>
-		<XunitRunnerVisualStudioVersion>2.5.1</XunitRunnerVisualStudioVersion>
+		<XunitVersion>2.7.0</XunitVersion>
+		<XunitRunnerVisualStudioVersion>2.5.7</XunitRunnerVisualStudioVersion>
 		<MoqVersion>4.20.69</MoqVersion>
-    <TestableIOSystemIOAbstractionsTestingHelpersVersion>19.2.69</TestableIOSystemIOAbstractionsTestingHelpersVersion>
+    <TestableIOSystemIOAbstractionsTestingHelpersVersion>20.0.15</TestableIOSystemIOAbstractionsTestingHelpersVersion>
 		<CoverletCollector>3.2.0</CoverletCollector>
 	</PropertyGroup>
 </Project>

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7905,13 +7905,14 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       },
       "engines": {
@@ -8507,6 +8508,25 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/espree": {
       "version": "7.3.1",
@@ -9139,9 +9159,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",
@@ -14128,9 +14148,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msgpackr": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.0.tgz",
-      "integrity": "sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
       }


### PR DESCRIPTION
* Bump xunit.runner.visualstudio from 2.5.1 to 2.5.7 (#188)

Bumps [xunit.runner.visualstudio](https://github.com/xunit/visualstudio.xunit) from 2.5.1 to 2.5.7.
- [Release notes](https://github.com/xunit/visualstudio.xunit/releases)
- [Commits](https://github.com/xunit/visualstudio.xunit/compare/2.5.1...2.5.7)

---
updated-dependencies:
- dependency-name: xunit.runner.visualstudio dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump xunit from 2.6.4 to 2.7.0 (#189)

Bumps [xunit](https://github.com/xunit/xunit) from 2.6.4 to 2.7.0.
- [Commits](https://github.com/xunit/xunit/compare/2.6.4...2.7.0)

---
updated-dependencies:
- dependency-name: xunit dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump es5-ext from 0.10.62 to 0.10.64 in /site (#187)

Bumps [es5-ext](https://github.com/medikoo/es5-ext) from 0.10.62 to 0.10.64.
- [Release notes](https://github.com/medikoo/es5-ext/releases)
- [Changelog](https://github.com/medikoo/es5-ext/blob/main/CHANGELOG.md)
- [Commits](https://github.com/medikoo/es5-ext/compare/v0.10.62...v0.10.64)

---
updated-dependencies:
- dependency-name: es5-ext dependency-type: indirect ...





* Bump follow-redirects from 1.15.3 to 1.15.4 in /site (#182)

Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.3 to 1.15.4.
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.3...v1.15.4)

---
updated-dependencies:
- dependency-name: follow-redirects dependency-type: indirect ...





* Bump msgpackr from 1.10.0 to 1.10.1 in /site (#175)

Bumps [msgpackr](https://github.com/kriszyp/msgpackr) from 1.10.0 to 1.10.1.
- [Release notes](https://github.com/kriszyp/msgpackr/releases)
- [Commits](https://github.com/kriszyp/msgpackr/compare/v1.10.0...v1.10.1)

---
updated-dependencies:
- dependency-name: msgpackr dependency-type: indirect ...





* Bump TestableIOSystemIOAbstractionsTestingHelpersVersion (#185)

Bumps `TestableIOSystemIOAbstractionsTestingHelpersVersion` from 19.2.69 to 20.0.15.

Updates `TestableIO.System.IO.Abstractions.TestingHelpers` from 19.2.69 to 20.0.15
- [Release notes](https://github.com/TestableIO/System.IO.Abstractions/releases)
- [Commits](https://github.com/TestableIO/System.IO.Abstractions/compare/v19.2.69...v20.0.15)

Updates `TestableIO.System.IO.Abstractions.Wrappers` from 19.2.69 to 20.0.15
- [Release notes](https://github.com/TestableIO/System.IO.Abstractions/releases)
- [Commits](https://github.com/TestableIO/System.IO.Abstractions/compare/v19.2.69...v20.0.15)

---
updated-dependencies:
- dependency-name: TestableIO.System.IO.Abstractions.TestingHelpers dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: TestableIO.System.IO.Abstractions.Wrappers dependency-type: direct:production update-type: version-update:semver-major ...





* update dotnet version

---------