### PR TITLE
Fix typo in documentation: 'cam' → 'can'

### DIFF
--- a/site/content/index.mdx
+++ b/site/content/index.mdx
@@ -21,7 +21,7 @@ title: Homepage
 
 <section className="content">
     <Article title="Background">
-    Crossroads is a tool to generate a single executable file to host any application and its content. It is an important component of the Morgan Stanley Modern Desktop Development Platform called ComposeUI. While .NET applications do have a native option to be self contained, this tool brings that feature to Node.js, Python, Java, etc applications as well. This way applications can be distributable without requiring local installation or an app store. Applications cam be packaged for both Windows and Linux by using just one tool.
+    Crossroads is a tool to generate a single executable file to host any application and its content. It is an important component of the Morgan Stanley Modern Desktop Development Platform called ComposeUI. While .NET applications do have a native option to be self contained, this tool brings that feature to Node.js, Python, Java, etc applications as well. This way applications can be distributable without requiring local installation or an app store. Applications can be packaged for both Windows and Linux by using just one tool.
     </Article>
     <Article title="Why Use Crossroads?">
         Crossroads allows you to:


### PR DESCRIPTION
This PR corrects a minor typo in the introduction section, changing 'cam' to 'can' for clarity.
